### PR TITLE
feat: preload Onest font

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -21,7 +21,7 @@ const { title, description, image = '/placeholder-social.jpg' } = Astro.props;
 </script>
 
 <!-- Fonts -->
-<link href="/OnestLight1602-hint.woff" rel="stylesheet" />
+<link rel="preload" as="font" href="/OnestLight1602-hint.woff" type="font/woff" crossorigin />
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,14 @@
   https://github.com/HermanMartinus/bearblog/blob/297026a877bc2ab2b3bdfbd6b9f7961c350917dd/templates/styles/blog/default.css
   License MIT: https://github.com/HermanMartinus/bearblog/blob/master/LICENSE.md
  */
+@font-face {
+	font-family: 'Onest';
+	src: url('/OnestLight1602-hint.woff') format('woff');
+	font-weight: 300;
+	font-style: normal;
+	font-display: swap;
+}
+
 body {
 	font-family: 'Onest';
 	margin: auto;


### PR DESCRIPTION
## Summary
- define `@font-face` for Onest font with proper display and weight settings
- preload Onest font in `BaseHead`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b371e5087c83278842c1be01173e6c