### PR TITLE
feat: add rel for external header links

### DIFF
--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -3,14 +3,21 @@ import type { HTMLAttributes } from 'astro/types';
 
 type Props = HTMLAttributes<'a'>;
 
-const { href, class: className, ...props } = Astro.props;
+const { href, class: className, rel, ...props } = Astro.props as Props;
 
 const { pathname } = Astro.url;
 const isActive = href === pathname || href === pathname.replace(/\/$/, '');
+const computedRel = props.target === "_blank" ? [rel, "noopener", "noreferrer"].filter(Boolean).join(' ') : rel;
 ---
 
-<a href={href} class:list={[className, { active: isActive }]} {...props}>
-	<slot />
+<a
+        href={href}
+        class:list={[className, { active: isActive }]}
+        rel={computedRel}
+        aria-current={isActive ? "page" : undefined}
+        {...props}
+>
+        <slot />
 </a>
 <style>
 	a {


### PR DESCRIPTION
## Summary
- add rel noopener noreferrer when HeaderLink target is _blank
- mark active header links with aria-current

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b371f3d8188327b2d8c1ba7d765479