### PR TITLE
Add table of contents to favorite links article

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,26 @@
+---
+---
+<nav id="toc">
+  <h2>Table of contents</h2>
+  <ul></ul>
+</nav>
+<script is:inline>
+  document.addEventListener('DOMContentLoaded', () => {
+    const article = document.querySelector('article');
+    if (!article) return;
+    const tocList = document.querySelector('#toc ul');
+    const headings = article.querySelectorAll('h1, h2, h3');
+    headings.forEach((heading) => {
+      if (!heading.id) return;
+      const li = document.createElement('li');
+      if (heading.tagName.toLowerCase() === 'h3') {
+        li.style.marginLeft = '1rem';
+      }
+      const a = document.createElement('a');
+      a.href = `#${heading.id}`;
+      a.textContent = heading.textContent;
+      li.appendChild(a);
+      tocList.appendChild(li);
+    });
+  });
+</script>

--- a/src/content/blog/favorite-links.mdx
+++ b/src/content/blog/favorite-links.mdx
@@ -4,6 +4,10 @@ description: ""
 pubDate: 2023-01-04
 ---
 
+import TableOfContents from '../../components/TableOfContents.astro';
+
+<TableOfContents />
+
 # Why
 
 I really want to share my knowledge for everyone and below I write some I think useful links of articles, video and posts.


### PR DESCRIPTION
## Summary
- add TableOfContents component to generate navigation from article headings
- include table of contents at the start of the favorite links post

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4a807617c83278907f6d4ce88a261