### PR TITLE
fix: update RSS feed handler for Astro 5

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,7 +2,7 @@ import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
-export async function get(context) {
+export async function GET(context) {
 	const posts = await getCollection('blog');
 	return rss({
 		title: SITE_TITLE,


### PR DESCRIPTION
## Summary
- rename `rss.xml` handler to `GET` for Astro 5 API compatibility

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b4a97a9e6483279db88a703e8c05f0